### PR TITLE
Enums and status() print formatting

### DIFF
--- a/cassini.py
+++ b/cassini.py
@@ -14,7 +14,7 @@ import logging
 import argparse
 from simple_mqtt_server import SimpleMQTTServer
 from simple_http_server import SimpleHTTPServer
-from saturn_printer import SaturnPrinter
+from saturn_printer import SaturnPrinter, PrintInfoStatus, CurrentStatus, FileStatus
 
 logging.basicConfig(
     level=logging.INFO,
@@ -55,9 +55,14 @@ def do_status(printers):
         status = p.desc['Data']['Status']
         print_info = status['PrintInfo']
         file_info = status['FileTransferInfo']
-        print(f"{p.addr[0]}: {attrs['Name']} ({attrs['MachineName']})  Status: {status['CurrentStatus']}")
-        print(f"          Print Status: {print_info['Status']} Layers: {print_info['CurrentLayer']}/{print_info['TotalLayer']} File: {print_info['Filename']}")
-        print(f"  File Transfer Status: {file_info['Status']}")
+        print(f"{p.addr[0]}:")
+        print(f"    {attrs['Name']} ({attrs['MachineName']})")
+        # print(f"    Status: {status['CurrentStatus']}")
+        print(f"    Machine Status: {CurrentStatus(status['CurrentStatus']).name}")
+        print(f"    Print Status: {PrintInfoStatus(print_info['Status']).name}")
+        print(f"    Layers: {print_info['CurrentLayer']}/{print_info['TotalLayer']}")
+        print(f"    File: {print_info['Filename']}")
+        print(f"    File Transfer Status: {FileStatus(file_info['Status']).name}")
 
 def do_watch(printer, interval=5, broadcast=None):
     status = printer.status()

--- a/cassini.py
+++ b/cassini.py
@@ -57,7 +57,6 @@ def do_status(printers):
         file_info = status['FileTransferInfo']
         print(f"{p.addr[0]}:")
         print(f"    {attrs['Name']} ({attrs['MachineName']})")
-        # print(f"    Status: {status['CurrentStatus']}")
         print(f"    Machine Status: {CurrentStatus(status['CurrentStatus']).name}")
         print(f"    Print Status: {PrintInfoStatus(print_info['Status']).name}")
         print(f"    Layers: {print_info['CurrentLayer']}/{print_info['TotalLayer']}")


### PR DESCRIPTION
Turned vars into proper enums. Using enums in status prints instead of just numbers. Added more newlines to status prints

I doubt most people have even 2 printers so I expanded the status prints a little to make them more readable:
![image](https://github.com/vvuk/cassini/assets/31737849/2c32827e-1236-4a71-8091-7f2ddfd93cb9)
