### PR TITLE
bugfix - send_command() enum fix

### DIFF
--- a/saturn_printer.py
+++ b/saturn_printer.py
@@ -309,7 +309,7 @@ class SaturnPrinter:
         timestamp = int(time.time() * 1000)
         cmd_data = {
             "Data": {
-                "Cmd": cmdid,
+                "Cmd": cmdid.value,
                 "Data": data,
                 "From": 0,
                 "MainboardID": self.id,


### PR DESCRIPTION
With the switch to enums we need to get the actual int value before dumping json payload