### PR TITLE
Fix crash when try to paint the status of the machine

### DIFF
--- a/saturn_printer.py
+++ b/saturn_printer.py
@@ -31,6 +31,7 @@ class CurrentStatus(Enum):
 # Status field inside PrintInfo
 class PrintInfoStatus(Enum):
     # TODO: double check these
+    READY = 0
     EXPOSURE = 2 
     RETRACTING = 3
     LOWERING = 4


### PR DESCRIPTION
Fix crash when check the status:

print(f"    Print Status: {PrintInfoStatus(print_info['Status']).name}")